### PR TITLE
Fix Studio component imports

### DIFF
--- a/Components/studio/Studio.jsx
+++ b/Components/studio/Studio.jsx
@@ -20,15 +20,15 @@ import {
   Film
 } from "lucide-react";
 
-import AudioUploader from "../components/studio/audiouploader";
-import TextUploader from "../components/studio/textuploader";
-import MicrophoneRecorder from "../components/studio/microphonerecorder";
-import TranscriptionDisplay from "../components/studio/transcriptiondisplay";
-import VoiceSelector from "../components/studio/voiceselector";
-import AnimationTypeSelector from "../components/studio/animationtypeselector";
-import AnimationPreview from "../components/studio/animationpreview";
-import ProcessingSteps from "../components/studio/processingsteps";
-import audiogenerationbutton from "../components/studio/audiogenerationbutton";
+import AudioUploader from "./audiouploader";
+import TextUploader from "./textuploader";
+import MicrophoneRecorder from "./microphonerecorder";
+import TranscriptionDisplay from "./transcriptiondisplay";
+import VoiceSelector from "./voiceselector";
+import AnimationTypeSelector from "./animationtypeselector";
+import AnimationPreview from "./animationpreview";
+import ProcessingSteps from "./processingsteps";
+import audiogenerationbutton from "./audiogenerationbutton";
 
 export default function Studio() {
   const [currentStep, setCurrentStep] = useState(1);

--- a/Components/studio/index.jsx
+++ b/Components/studio/index.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Studio from "../components/studio/Studio";
+import Studio from "./Studio";
 
 export default function Home() {
   return <Studio />;


### PR DESCRIPTION
## Summary
- fix Studio import in index.jsx
- ensure Studio component uses correct relative imports

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Parsing error in pages/api/generate-audio.js)*
- `npm run build` *(fails: fetch font `Geist` & syntax error in pages/api/generate-audio.js)*

------
https://chatgpt.com/codex/tasks/task_e_688e762edc50832298484e7ef55674bb