### PR TITLE
fix: allow disabling voice selector

### DIFF
--- a/Components/studio/voiceselector.jsx
+++ b/Components/studio/voiceselector.jsx
@@ -1,15 +1,15 @@
 import React from "react";
 
-export default function VoiceSelector({ selectedVoice, selectedStyle, onVoiceChange, onStyleChange }) {
+export default function VoiceSelector({ selectedVoice, selectedStyle, onVoiceChange, onStyleChange, disabled }) {
   return (
     <div>
       <label>Voice Type:</label>
-      <select value={selectedVoice} onChange={e => onVoiceChange(e.target.value)}>
+      <select value={selectedVoice} onChange={e => onVoiceChange(e.target.value)} disabled={disabled}>
         <option value="female">Female</option>
         <option value="male">Male</option>
       </select>
       <label>Visual Style:</label>
-      <select value={selectedStyle} onChange={e => onStyleChange(e.target.value)}>
+      <select value={selectedStyle} onChange={e => onStyleChange(e.target.value)} disabled={disabled}>
         <option value="abstract">Abstract</option>
         <option value="realistic">Realistic</option>
         <option value="cartoon">Cartoon</option>


### PR DESCRIPTION
## Summary
- allow voice selector inputs to be disabled when component is inactive

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e72df2e44832290a950ffd92ae410