### PR TITLE
Add Node-based unit test for audio generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "echo \"No tests defined\" && exit 0"
+    "test": "node --test"
   },
   "dependencies": {
     "react": "19.1.0",

--- a/pages/api/generate-audio.ts
+++ b/pages/api/generate-audio.ts
@@ -1,24 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
-
-function generateSilentWav(duration = 1, sampleRate = 22050) {
-  const totalSamples = Math.floor(duration * sampleRate);
-  const header = Buffer.alloc(44);
-  header.write("RIFF", 0);
-  header.writeUInt32LE(36 + totalSamples * 2, 4);
-  header.write("WAVE", 8);
-  header.write("fmt ", 12);
-  header.writeUInt32LE(16, 16);
-  header.writeUInt16LE(1, 20);
-  header.writeUInt16LE(1, 22);
-  header.writeUInt32LE(sampleRate, 24);
-  header.writeUInt32LE(sampleRate * 2, 28);
-  header.writeUInt16LE(2, 32);
-  header.writeUInt16LE(16, 34);
-  header.write("data", 36);
-  header.writeUInt32LE(totalSamples * 2, 40);
-  const data = Buffer.alloc(totalSamples * 2);
-  return Buffer.concat([header, data]);
-}
+import { generateSilentWav } from "@/utils/generateSilentWav";
 
 export default function handler(
   req: NextApiRequest,

--- a/src/utils/generateSilentWav.js
+++ b/src/utils/generateSilentWav.js
@@ -1,0 +1,19 @@
+export function generateSilentWav(duration = 1, sampleRate = 22050) {
+  const totalSamples = Math.floor(duration * sampleRate);
+  const header = Buffer.alloc(44);
+  header.write("RIFF", 0);
+  header.writeUInt32LE(36 + totalSamples * 2, 4);
+  header.write("WAVE", 8);
+  header.write("fmt ", 12);
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20);
+  header.writeUInt16LE(1, 22);
+  header.writeUInt32LE(sampleRate, 24);
+  header.writeUInt32LE(sampleRate * 2, 28);
+  header.writeUInt16LE(2, 32);
+  header.writeUInt16LE(16, 34);
+  header.write("data", 36);
+  header.writeUInt32LE(totalSamples * 2, 40);
+  const data = Buffer.alloc(totalSamples * 2);
+  return Buffer.concat([header, data]);
+}

--- a/src/utils/generateSilentWav.test.js
+++ b/src/utils/generateSilentWav.test.js
@@ -1,0 +1,8 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { generateSilentWav } from './generateSilentWav.js';
+
+test('generateSilentWav creates correct buffer length for 1s at 22050Hz', () => {
+  const buffer = generateSilentWav(1, 22050);
+  assert.strictEqual(buffer.length, 44144);
+});


### PR DESCRIPTION
## Summary
- extract WAV buffer creation into reusable utility
- cover silent audio generator with Node test
- switch `npm test` to Node's built-in test runner

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fbf2bec008322aafa865891dd7954